### PR TITLE
Add More Device Parameters & Improve List Example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,6 @@ authors = ["Jeremy Soller <jackpot51@gmail.com>"]
 
 [dependencies]
 "libparted-sys" = { "git" = "https://github.com/system76/libparted-sys.git" }
+
+[dev-dependencies]
+libc = "*"

--- a/src/device.rs
+++ b/src/device.rs
@@ -15,6 +15,8 @@ use libparted_sys::{
     ped_device_end_external_access,
 };
 
+pub use libparted_sys::PedDeviceType as DeviceType;
+
 use super::cvt;
 
 pub struct Device(*mut PedDevice);
@@ -22,6 +24,35 @@ pub struct Device(*mut PedDevice);
 pub struct DeviceIter(*mut PedDevice);
 
 pub struct DeviceExternalAccess<'a>(&'a mut Device);
+
+pub struct Geometry {
+    pub cylinders: i32,
+    pub heads: i32,
+    pub sectors: i32
+}
+
+macro_rules! get_bool {
+    ($field:tt) => {
+        pub fn $field(&self) -> bool {
+            unsafe { *self.0 }.$field != 0
+        }
+    }
+}
+
+macro_rules! get_geometry {
+    ($kind:tt) => {
+        pub fn $kind(&self) -> Geometry {
+            unsafe {
+                let raw = (*self.0).$kind;
+                Geometry {
+                    cylinders: raw.cylinders as i32,
+                    heads: raw.heads as i32,
+                    sectors: raw.sectors as i32
+                }
+            }
+        }
+    }
+}
 
 impl Device {
     pub fn devices(probe: bool) -> DeviceIter {
@@ -74,7 +105,11 @@ impl Device {
         }
     }
 
-    // TODO pub fn type
+    pub fn type_(&self) -> DeviceType {
+        unsafe {
+            (*self.0).type_ as DeviceType
+        }
+    }
 
     pub fn sector_size(&self) -> u64 {
         unsafe {
@@ -100,13 +135,26 @@ impl Device {
         }
     }
 
-    pub fn read_only(&self) -> bool {
+    get_bool!(read_only);
+    get_bool!(external_mode);
+    get_bool!(dirty);
+    get_bool!(boot_dirty);
+    get_geometry!(hw_geom);
+    get_geometry!(bios_geom);
+
+    pub fn host(&self) -> i16 {
         unsafe {
-            (*self.0).read_only != 0
+            (*self.0).host as i16
         }
     }
 
-    //TODO: add more params
+    pub fn did(&self) -> i16 {
+        unsafe {
+            (*self.0).did as i16
+        }
+    }
+
+    // TODO: arch_specific
 }
 
 impl Iterator for DeviceIter {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@ extern crate libparted_sys;
 
 use std::io;
 
-pub use self::device::Device;
+pub use self::device::{Device, Geometry};
 pub use self::disk::Disk;
 pub use self::partition::Partition;
 


### PR DESCRIPTION
A handful of missing parameters were added to the **Device** structure, and these parameters were added to the list example. In addition, the list example will now check if it is being run by root, as otherwise errors would be generated, and no output would be given.