### PR TITLE
Add More Device Methods

### DIFF
--- a/src/alignment.rs
+++ b/src/alignment.rs
@@ -1,3 +1,64 @@
-use libparted_sys::PedAlignment;
+use libparted_sys::{
+    PedAlignment,
+    ped_alignment_destroy,
+    ped_alignment_duplicate,
+    ped_alignment_init,
+    ped_alignment_intersect,
+    ped_alignment_new,
+};
 
-pub struct Alignment(pub(crate) *mut PedAlignment);
+use std::io;
+use std::marker::PhantomData;
+use super::cvt;
+
+pub struct Alignment<'a> {
+    pub(crate) alignment: *mut PedAlignment,
+    pub(crate) phantom: PhantomData<&'a PedAlignment>
+}
+
+impl<'a> Alignment<'a> {
+    /// Return an alignment object representing all sectors that are of the form
+    /// `offset + X * grain_size`.
+    pub fn new(offset: i64, grain_size: i64) -> io::Result<Alignment<'a>> {
+        let alignment = unsafe { ped_alignment_new(offset, grain_size) };
+        if alignment.is_null() {
+            Err(io::Error::new(io::ErrorKind::Other, "failed to allocate allignment"))
+        } else {
+            Ok(Alignment { alignment, phantom: PhantomData })
+        }
+    }
+
+    /// Initializes a preallocated piece of memory for an alignment object.
+    pub fn init(&mut self, offset: i64, grain_size: i64) -> io::Result<()> {
+        cvt(unsafe { ped_alignment_init(self.alignment, offset, grain_size) })?;
+        Ok(())
+    }
+
+    /// Returns a new **Alignment** object if an intersection can between
+    /// itself and a given `other` **Alignment**.
+    pub fn intersect(&self, other: &Alignment) -> Option<Alignment<'a>> {
+        let alignment = unsafe {
+            ped_alignment_intersect(self.alignment, other.alignment)
+        };
+        if alignment.is_null() {
+            None
+        } else {
+            Some(Alignment { alignment, phantom: PhantomData })
+        }
+    }
+}
+
+impl<'a> Clone for Alignment<'a> {
+    fn clone(&self) -> Self {
+        Alignment {
+            alignment: unsafe { ped_alignment_duplicate(self.alignment) },
+            phantom: PhantomData
+        }
+    }
+}
+
+impl<'a> Drop for Alignment<'a> {
+    fn drop(&mut self) {
+        unsafe { ped_alignment_destroy(self.alignment) }
+    }
+}

--- a/src/alignment.rs
+++ b/src/alignment.rs
@@ -1,0 +1,3 @@
+use libparted_sys::PedAlignment;
+
+pub struct Alignment(pub(crate) *mut PedAlignment);

--- a/src/constraint.rs
+++ b/src/constraint.rs
@@ -1,0 +1,3 @@
+use libparted_sys::PedConstraint;
+
+pub struct Constraint(pub(crate) *mut PedConstraint);

--- a/src/constraint.rs
+++ b/src/constraint.rs
@@ -1,3 +1,17 @@
-use libparted_sys::PedConstraint;
+use std::marker::PhantomData;
 
-pub struct Constraint(pub(crate) *mut PedConstraint);
+use libparted_sys::{
+    PedConstraint,
+    ped_constraint_destroy
+};
+
+pub struct Constraint<'a> {
+    pub(crate) constraint: *mut PedConstraint,
+    pub(crate) phantom: PhantomData<&'a PedConstraint>
+}
+
+impl<'a> Drop for Constraint<'a> {
+    fn drop(&mut self) {
+        unsafe { ped_constraint_destroy(self.constraint) }
+    }
+}

--- a/src/device.rs
+++ b/src/device.rs
@@ -1,5 +1,6 @@
 use std::ffi::{CStr, CString};
 use std::io::{Error, ErrorKind, Result};
+use std::marker::PhantomData;
 use std::os::unix::ffi::OsStrExt;
 use std::os::raw::c_void;
 use std::path::Path;
@@ -120,24 +121,39 @@ impl Device {
         Ok(())
     }
 
-    pub fn get_constraint(&self) -> Constraint {
-        unsafe { Constraint(ped_device_get_constraint(self.0)) }
+    pub fn get_constraint<'a>(&'a self) -> Constraint<'a> {
+        Constraint {
+            constraint: unsafe { ped_device_get_constraint(self.0) },
+            phantom: PhantomData
+        }
     }
 
-    pub fn get_minimal_aligned_constraint(&self) -> Constraint {
-        unsafe { Constraint(ped_device_get_minimal_aligned_constraint(self.0)) }
+    pub fn get_minimal_aligned_constraint<'a>(&'a self) -> Constraint<'a> {
+        Constraint {
+            constraint: unsafe { ped_device_get_minimal_aligned_constraint(self.0) },
+            phantom: PhantomData
+        }
     }
 
-    pub fn get_optimal_aligned_constraint(&self) -> Constraint {
-        unsafe { Constraint(ped_device_get_optimal_aligned_constraint(self.0)) }
+    pub fn get_optimal_aligned_constraint<'a>(&'a self) -> Constraint<'a> {
+        Constraint {
+            constraint: unsafe { ped_device_get_optimal_aligned_constraint(self.0) },
+            phantom: PhantomData
+        }
     }
 
-    pub fn get_minimum_alignment(&self) -> Alignment {
-        unsafe { Alignment(ped_device_get_minimum_alignment(self.0)) }
+    pub fn get_minimum_alignment<'a>(&'a self) -> Alignment<'a> {
+        Alignment {
+            alignment: unsafe { ped_device_get_minimum_alignment(self.0) },
+            phantom: PhantomData
+        }
     }
 
-    pub fn get_optimal_alignment(&self) -> Alignment {
-        unsafe { Alignment(ped_device_get_optimum_alignment(self.0)) }
+    pub fn get_optimal_alignment<'a>(&'a self) -> Alignment<'a> {
+        Alignment {
+            alignment: unsafe { ped_device_get_optimum_alignment(self.0) },
+            phantom: PhantomData
+        }
     }
 
     pub fn model(&self) -> &[u8] {

--- a/src/device.rs
+++ b/src/device.rs
@@ -1,6 +1,7 @@
 use std::ffi::{CStr, CString};
 use std::io::{Error, ErrorKind, Result};
 use std::os::unix::ffi::OsStrExt;
+use std::os::raw::c_void;
 use std::path::Path;
 use std::ptr;
 
@@ -13,6 +14,10 @@ use libparted_sys::{
     ped_device_close,
     ped_device_begin_external_access,
     ped_device_end_external_access,
+    ped_device_sync,
+    ped_device_sync_fast,
+    ped_device_write,
+    ped_device_is_busy
 };
 
 use super::cvt;
@@ -60,6 +65,54 @@ impl Device {
             ped_device_begin_external_access(self.0)
         })?;
         Ok(DeviceExternalAccess(self))
+    }
+
+    /// Flushes all write-behind caches that might be holding up writes.
+    /// 
+    /// It is slow because it guarantees cache coherency among all relevant caches.
+    pub fn sync(&mut self) -> Result<()> {
+        cvt(unsafe { ped_device_sync(self.0) })?;
+        Ok(())
+    }
+
+    /// Flushes all write-behind caches that might be holding writes.
+    /// 
+    /// It does not ensure cache coherency with other caches.
+    pub fn sync_fast(&mut self) -> Result<()> {
+        cvt(unsafe { ped_device_sync_fast(self.0) })?;
+        Ok(())
+    }
+
+    /// Indicates whether the device is busy.
+    pub fn is_busy(&self) -> bool {
+        unsafe { ped_device_is_busy(self.0) != 0 }
+    }
+
+    /// Attempts to write the data within the buffer to the device, starting
+    /// at the **start_sector**, and spanning across **sectors**.
+    pub fn write_to_sectors(
+        &mut self,
+        buffer: &[u8],
+        start_sector: i64,
+        sectors: i64
+    ) -> Result<()> {
+        let total_size = self.sector_size() as usize * sectors as usize;
+
+        // Ensure that the data will fit within the region of sectors.
+        assert!(buffer.len() <= total_size);
+        
+        // Write as much data as needed to fill the entire sector, writing
+        // zeros in the unused space, and obtaining a pointer to the buffer.
+        let mut sector_buffer: Vec<u8> = Vec::with_capacity(total_size);
+        sector_buffer.copy_from_slice(buffer);
+        for index in buffer.len()..total_size {
+            sector_buffer[index] = b'0';
+        }
+        let sector_ptr = sector_buffer.as_slice().as_ptr() as *const c_void;
+
+        // Then attempt to write the data to the device.
+        cvt(unsafe { ped_device_write(self.0, sector_ptr, start_sector, sectors) })?;
+        Ok(())
     }
 
     pub fn model(&self) -> &[u8] {

--- a/src/device.rs
+++ b/src/device.rs
@@ -17,10 +17,15 @@ use libparted_sys::{
     ped_device_sync,
     ped_device_sync_fast,
     ped_device_write,
-    ped_device_is_busy
+    ped_device_is_busy,
+    ped_device_get_constraint,
+    ped_device_get_minimal_aligned_constraint,
+    ped_device_get_minimum_alignment,
+    ped_device_get_optimal_aligned_constraint,
+    ped_device_get_optimum_alignment
 };
 
-use super::cvt;
+use super::{cvt, Alignment, Constraint};
 
 pub struct Device(*mut PedDevice);
 
@@ -113,6 +118,26 @@ impl Device {
         // Then attempt to write the data to the device.
         cvt(unsafe { ped_device_write(self.0, sector_ptr, start_sector, sectors) })?;
         Ok(())
+    }
+
+    pub fn get_constraint(&self) -> Constraint {
+        unsafe { Constraint(ped_device_get_constraint(self.0)) }
+    }
+
+    pub fn get_minimal_aligned_constraint(&self) -> Constraint {
+        unsafe { Constraint(ped_device_get_minimal_aligned_constraint(self.0)) }
+    }
+
+    pub fn get_optimal_aligned_constraint(&self) -> Constraint {
+        unsafe { Constraint(ped_device_get_optimal_aligned_constraint(self.0)) }
+    }
+
+    pub fn get_minimum_alignment(&self) -> Alignment {
+        unsafe { Alignment(ped_device_get_minimum_alignment(self.0)) }
+    }
+
+    pub fn get_optimal_alignment(&self) -> Alignment {
+        unsafe { Alignment(ped_device_get_optimum_alignment(self.0)) }
     }
 
     pub fn model(&self) -> &[u8] {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,10 +2,14 @@ extern crate libparted_sys;
 
 use std::io;
 
+pub use self::alignment::Alignment;
+pub use self::constraint::Constraint;
 pub use self::device::Device;
 pub use self::disk::Disk;
 pub use self::partition::Partition;
 
+mod alignment;
+mod constraint;
 mod device;
 mod disk;
 mod partition;


### PR DESCRIPTION
This adds the following methods to `Device`

- get_constraint
- get_minimal_aligned_constraint
- get_optimal_aligned_constraint
- get_minimal_alignment
- get_optimal_alignment
- is_busy
- sync
- sync_fast
- write_to_sectors
  
As well as the following for `Alignment`:

- new
- init
- intersect

Along with new `Alignment` and `Constraint` structures.

Further method implementations will require #3 to be merged beforehand.