### PR TITLE
Add More Examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Jeremy Soller <jackpot51@gmail.com>"]
 
 [dependencies]
-"libparted-sys" = { "git" = "https://github.com/system76/libparted-sys.git" }
+libparted-sys = { git = "https://github.com/system76/libparted-sys.git" }
 
 [dev-dependencies]
 libc = "*"

--- a/examples/list.rs
+++ b/examples/list.rs
@@ -13,58 +13,38 @@ fn list() -> Result<()> {
         let hw_geom = device.hw_geom();
         let bios_geom = device.bios_geom();
 
-        println!(
-            "Device {}
-    Model: {:?}
-    Path: {:?}
-    Size: {} MB
-    Type: {:?}
-    Open Count: {}
-    Read Only: {}
-    External Mode: {}
-    Dirty: {}
-    Boot Dirty: {}
-    Hardware Geometry:
-        Cylinders: {}
-        Heads: {}
-        Sectors: {}
-    BIOS Geometry:
-        Cylinders: {}
-        Heads: {}
-        Sectors: {}
-    Host: {}
-    Did: {}",
-            dev_i,
-            str::from_utf8(device.model()),
-            device.path(),
-            device.length() * device.sector_size() / 1000000,
-            device.type_(),
-            device.open_count(),
-            device.read_only(),
-            device.external_mode(),
-            device.dirty(),
-            device.boot_dirty(),
-            hw_geom.cylinders,
-            hw_geom.heads,
-            hw_geom.sectors,
-            bios_geom.cylinders,
-            bios_geom.heads,
-            bios_geom.sectors,
-            device.host(),
-            device.did()
-        );
+        println!("Device {}", dev_i);
+        println!("    Mode:          {:?}", str::from_utf8(device.model()));
+        println!("    Path:          {:?}", device.path());
+        println!("    Size:          {} MB", device.length() * device.sector_size() / 1000000);
+        println!("    Type:          {:?}", device.type_());
+        println!("    Open Count:    {}", device.open_count());
+        println!("    Read Only:     {}", device.read_only());
+        println!("    External Mode: {}", device.external_mode());
+        println!("    Dirty:         {}", device.dirty());
+        println!("    Boot Dirty:    {}", device.boot_dirty());
+        println!("    Hardware Geometry:");
+        println!("        Cylinders: {}", hw_geom.cylinders);
+        println!("        Heads:     {}", hw_geom.heads);
+        println!("        Sectors:   {}", hw_geom.sectors);
+        println!("    BIOS Geometry:");
+        println!("        Cylinders: {}", bios_geom.cylinders);
+        println!("        Heads:     {}", bios_geom.heads);
+        println!("        Sectors:   {}", bios_geom.sectors);
+        println!("    Host:          {}", device.host());
+        println!("    Did:           {}", device.did());
 
         let disk = Disk::new(device)?;
         eprintln!("    Disk Type: {:?}", disk.get_disk_type_name().map(str::from_utf8));
 
         for (part_i, part) in disk.parts().enumerate() {
             println!("    Part {}", part_i);
-            println!("        Name:   {:?}", str::from_utf8(part.type_get_name()));
+            println!("        Name:   {:?}", part.type_get_name());
             println!("        Type:   {:?}", part.name());
             println!("        Path:   {:?}", part.get_path());
             println!("        Active: {}", part.is_active());
             println!("        Busy:   {}", part.is_busy());
-            println!("        FS:     {:?}", part.fs_type_name().map(str::from_utf8));
+            println!("        FS:     {:?}", part.fs_type_name());
             println!("        Start:  {}", part.geom_start());
             println!("        End:    {}", part.geom_end());
             println!("        Length: {}", part.geom_length());

--- a/examples/mkfs.rs
+++ b/examples/mkfs.rs
@@ -1,0 +1,111 @@
+extern crate libparted;
+use libparted::*;
+use std::io;
+use std::env;
+use std::process::exit;
+
+fn get_config<I: Iterator<Item = String>>(mut args: I) -> io::Result<(String, String, u64, u64)> {
+    fn config_err(msg: &'static str) -> io::Error {
+        io::Error::new(io::ErrorKind::InvalidData, msg)
+    }
+
+    let device = args.next().ok_or_else(|| config_err("no device provided"))?;
+    let fs = args.next().ok_or_else(|| config_err("no fs provided"))?;
+    let start_str = args.next().ok_or_else(|| config_err("no start provided"))?;
+    let length_str = args.next().ok_or_else(|| config_err("no length provided"))?;
+    let start = start_str.parse::<u64>().or_else(|_| Err(config_err("invalid start value")))?;
+    let length = length_str.parse::<u64>().or_else(|_| Err(config_err("invalid start value")))?;
+
+    Ok((device, fs, start, length))
+}
+
+// TODO: Figure out how to get the file system type to be properly set.
+fn create_partition_with_filesystem(device: &str, fs: &str, start: u64, length: u64) -> Result<(), ()> {
+    let dev = match Device::new(&device) {
+        Ok(device) => device,
+        Err(why) => {
+            eprintln!("mkfs: unable to open {} device: {}", device, why);
+            return Err(())
+        }
+    };
+
+    let geometry = match Geometry::new(&dev, start as i64, length as i64) {
+        Ok(geometry) => geometry,
+        Err(why) => {
+            eprintln!("unable to create new geometry: {}", why);
+            return Err(());
+        }
+    };
+
+    let mut disk = match Disk::new(dev) {
+        Ok(disk) => disk,
+        Err(why) => {
+            eprintln!("mkfs: unable to open {} disk: {}", device, why);
+            return Err(())
+        }
+    };
+
+    let fs_type = match FileSystemType::get(&fs) {
+        Some(fs_type) => fs_type,
+        None => {
+            eprintln!("unable to get {} file system type", fs);
+            return Err(());
+        }
+    };
+
+    let part_type = PartitionType::PED_PARTITION_NORMAL;
+
+    let mut partition = match Partition::new(&mut disk, part_type, &fs_type, geometry.start(), geometry.length()) {
+        Ok(partition) => partition,
+        Err(why) => {
+            eprintln!("unable to create partition: {}", why);
+            return Err(());
+        }
+    };
+
+    let constraint = match geometry.exact() {
+        Some(constraint) => constraint,
+        None => {
+            eprintln!("unable to get exact constraint from geometry");
+            return Err(());
+        }
+    };
+
+    // Set as a boot partition.
+    // if partition.is_flag_available(PartitionFlag::PED_PARTITION_BOOT) {
+    //     let _ = partition.set_flag(PartitionFlag::PED_PARTITION_BOOT, true);
+    // }
+
+    if let Err(why) = disk.add_partition(&mut partition, &constraint) {
+        eprintln!("unable to add partition to disk: {}", why);
+        return Err(());
+    }
+
+    if let Err(why) = partition.set_system(&fs_type) {
+        eprintln!("unable to set the system type of the partition to the file system type: {}", why);
+        return Err(());
+    }
+
+    if partition.is_flag_available(PartitionFlag::PED_PARTITION_LBA) {
+        let _ = partition.set_flag(PartitionFlag::PED_PARTITION_LBA, true);
+    }
+
+    if let Err(why) = disk.commit() {
+        eprintln!("unable to commit changes to disk: {}", why);
+        return Err(());
+    }
+    Ok(())
+}
+
+fn main() {
+    let (device, fs, start, length) = match get_config(env::args().skip(1)) {
+        Ok(config) => config,
+        Err(why) => {
+            eprintln!("mkfs error: {}", why);
+            eprintln!("\tUsage:\n\t\tmkfs <device> <filesystem> <start> <length>");
+            exit(1);
+        }
+    };
+
+    exit(create_partition_with_filesystem(&device, &fs, start, length).ok().map_or(1, |_| 0));
+}

--- a/examples/mkpart.rs
+++ b/examples/mkpart.rs
@@ -1,0 +1,96 @@
+extern crate libparted;
+use libparted::*;
+use std::io;
+use std::env;
+use std::process::exit;
+
+fn get_config<I: Iterator<Item = String>>(mut args: I) -> io::Result<(String, u64, u64)> {
+    fn config_err(msg: &'static str) -> io::Error {
+        io::Error::new(io::ErrorKind::InvalidData, msg)
+    }
+
+    let device = args.next().ok_or_else(|| config_err("no device provided"))?;
+    let start_str = args.next().ok_or_else(|| config_err("no start provided"))?;
+    let length_str = args.next().ok_or_else(|| config_err("no length provided"))?;
+    let start = start_str.parse::<u64>().or_else(|_| Err(config_err("invalid start value")))?;
+    let length = length_str.parse::<u64>().or_else(|_| Err(config_err("invalid start value")))?;
+
+    Ok((device, start, length))
+}
+
+// TODO: Figure out how to create an 'Unformatted' partition.
+fn create_partition(device: &str, start: u64, length: u64) -> Result<(), ()> {
+    let dev = match Device::new(&device) {
+        Ok(device) => device,
+        Err(why) => {
+            eprintln!("mkpart: unable to open {} device: {}", device, why);
+            return Err(())
+        }
+    };
+
+    let geometry = match Geometry::new(&dev, start as i64, length as i64) {
+        Ok(geometry) => geometry,
+        Err(why) => {
+            eprintln!("unable to create new geometry: {}", why);
+            return Err(());
+        }
+    };
+
+    let mut disk = match Disk::new(dev) {
+        Ok(disk) => disk,
+        Err(why) => {
+            eprintln!("mkpart: unable to open {} disk: {}", device, why);
+            return Err(())
+        }
+    };
+
+    use std::ptr;
+    let fs_type = FileSystemType::from_raw(ptr::null_mut());
+    let part_type = PartitionType::PED_PARTITION_NORMAL;
+
+    let mut partition = match Partition::new(&mut disk, part_type, &fs_type, geometry.start(), geometry.length()) {
+        Ok(partition) => partition,
+        Err(why) => {
+            eprintln!("unable to create partition: {}", why);
+            return Err(());
+        }
+    };
+
+    let constraint = match geometry.exact() {
+        Some(constraint) => constraint,
+        None => {
+            eprintln!("unable to get exact constraint from geometry");
+            return Err(());
+        }
+    };
+
+    if let Err(why) = disk.add_partition(&mut partition, &constraint) {
+        eprintln!("unable to add partition to disk: {}", why);
+        return Err(());
+    }
+
+    if partition.is_flag_available(PartitionFlag::PED_PARTITION_LBA) {
+        let _ = partition.set_flag(PartitionFlag::PED_PARTITION_LBA, true);
+    }
+
+    if let Err(why) = disk.commit() {
+        eprintln!("unable to commit changes to disk: {}", why);
+        return Err(());
+    }
+
+    Ok(())
+}
+
+
+fn main() {
+    let (device, start, length) = match get_config(env::args().skip(1)) {
+        Ok(config) => config,
+        Err(why) => {
+            eprintln!("mkpart error: {}", why);
+            eprintln!("\tUsage:\n\t\tmkpart <device> <start> <length>");
+            exit(1);
+        }
+    };
+
+    exit(create_partition(&device, start, length).ok().map_or(1, |_| 0));
+}

--- a/examples/print-align.rs
+++ b/examples/print-align.rs
@@ -1,0 +1,49 @@
+extern crate libparted;
+
+use std::env::args;
+use std::process::exit;
+use libparted::*;
+
+fn main() {
+    let args = args().collect::<Vec<String>>();
+    if args.len() != 2 {
+        eprintln!("a device must be specified");
+        exit(1);
+    }
+
+    let device = match Device::get(&args[1]) {
+        Ok(device) => device,
+        Err(why) => {
+            eprintln!("unable to get {} device: {}", args[1], why);
+            exit(1);
+        }
+    };
+
+    match device.get_minimum_alignment() {
+        Some(alignment) => println!("minimum: {} {}", alignment.offset(), alignment.grain_size()),
+        None            => println!("minimum: - -")
+    }
+
+    match device.get_optimum_alignment() {
+        Some(alignment) => println!("optimum: {} {}", alignment.offset(), alignment.grain_size()),
+        None            => println!("optimum: - -")
+    }
+
+    let disk = match Disk::new(device) {
+        Ok(disk) => disk,
+        Err(why) => {
+            eprintln!("unable to open disk from {} device: {}", args[1], why);
+            exit(1);
+        }
+    };
+
+    match disk.get_partition_alignment() {
+        Ok(alignment) => println!("partition alignment: {} {}", alignment.offset(), alignment.grain_size()),
+        Err(why) => {
+            eprintln!("unable to get disk partition alignment from {}: {}", args[1], why);
+            exit(1);
+        }
+    }
+
+    drop(disk);
+}

--- a/examples/print-max.rs
+++ b/examples/print-max.rs
@@ -1,0 +1,28 @@
+extern crate libparted;
+
+use std::env::args;
+use std::process::exit;
+use libparted::*;
+
+fn main() {
+    let args = args().collect::<Vec<String>>();
+    if args.len() != 2 {
+        eprintln!("a device must be specified");
+        exit(1);
+    }
+
+    let disk = match Device::get(&args[1]).and_then(Disk::new) {
+        Ok(disk) => disk,
+        Err(why) => {
+            eprintln!("unable to get {} disk: {}", args[1], why);
+            exit(1);
+        }
+    };
+
+    println!(
+        "max len: {}\nmax start sector: {}",
+        disk.max_partition_length(),
+        disk.max_partition_start_sector()
+    );
+
+}

--- a/examples/resize.rs
+++ b/examples/resize.rs
@@ -1,0 +1,48 @@
+extern crate libparted;
+
+use std::env::args;
+use std::process::exit;
+use libparted::*;
+
+fn main() {
+    let args = args().collect::<Vec<String>>();
+    if !(args.len() == 2 || args.len() == 4) {
+        eprintln!(
+            "usage: {0} <device>\n       {0} <device> <start> <length>",
+            args[0]
+        );
+        exit(1);
+    }
+
+    let dev = match Device::new(&args[1]) {
+        Ok(dev) => dev,
+        Err(why) => {
+            eprintln!("cannot create/open device {}: {}", args[1], why);
+            exit(1);
+        }
+    };
+
+    let geom = match Geometry::new(&dev, 0, dev.length() as i64) {
+        Ok(geom) => geom,
+        Err(why) => {
+            eprintln!("cannot create geometry: {}", why);
+            exit(1);
+        }
+    };
+
+    let mut fs = match FileSystem::open(&geom) {
+        Some(fs) => fs,
+        None => {
+            eprintln!("cannot read file system");
+            exit(1);
+        }
+    };
+
+    match fs.resize(&geom, None) {
+        Ok(()) => println!("filesystem resized"),
+        Err(why) => {
+            eprintln!("cannot resize file system: {}", why);
+            exit(1);
+        }
+    }
+}

--- a/src/disk.rs
+++ b/src/disk.rs
@@ -173,7 +173,7 @@ impl<'a> Disk<'a> {
     /// special requirements on the start and end of partitions. Therefore, having an overly
     /// strict constraint will probably mean that this function will fail (in which case `part`
     /// will be left unmodified) `part` is assigned a number (`part.num`) in this process.
-    pub fn add_partition(&self, part: &Partition, constraint: &Constraint) -> Result<()> {
+    pub fn add_partition(&mut self, part: &mut Partition, constraint: &Constraint) -> Result<()> {
         cvt(unsafe { ped_disk_add_partition(self.disk, part.part, constraint.constraint) })?;
         Ok(())
     }


### PR DESCRIPTION
These can be used as a guideline to implement real world software w/ the libparted API. A handful of API fixes have also been integrated so that the examples could be created, and actually work.

Several issues still need to be worked out before the examples are working perfectly. Notably, I haven't yet figured out how to get the newly-created partitions to be set to their corresponding file system types. Rather than being set to the specified type, they are being created as _unknown_ file systems. 