### PR TITLE
Improve partition removal methods

### DIFF
--- a/src/partition.rs
+++ b/src/partition.rs
@@ -5,7 +5,7 @@ use std::marker::PhantomData;
 use std::path::Path;
 use std::ptr;
 use std::str;
-use super::{cvt, Device, Disk, FileSystemType, Geometry};
+use super::{cvt, Disk, FileSystemType, Geometry};
 
 use libparted_sys::{ped_partition_destroy, ped_partition_get_flag, ped_partition_get_name,
                     ped_partition_get_path, ped_partition_is_active, ped_partition_is_busy,


### PR DESCRIPTION
- Removes the `delete_partition` method as it's not required in the context of Rust.
- `remove_partition` is now made as an unsafe method that takes a `*mut PedPartition`
- `get_partition_raw` methods were added to get raw pointers for partitions
- `remove_by_number` and `remove_by_sector` were added to replace `remove_partition`