### PR TITLE
Fix build on recent Rust compilers (>1.39)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 
 [dependencies]
 libc = "0.2"
-libparted-sys = "0.1.1"
+libparted-sys = "0.3"
 
 [dev-dependencies]
 libc = "0.2"


### PR DESCRIPTION
`libparted-sys` 0.1 depends on an old `bindgen` version that doesn't compile on recent Rust compilers. This PR changes the version of `libparted-sys` we use to 0.3.

`libparted-sys` 0.3's API isn't fully compatible with the old version, as the enums (which this crate re-exports) are now marked as non-exhaustive.