### PR TITLE
Clean up partition table creation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@ use std::io;
 pub use self::alignment::Alignment;
 pub use self::constraint::Constraint;
 pub use self::device::{CHSGeometry, Device, DeviceExternalAccess, DeviceIter, DeviceType};
-pub use self::disk::{Disk, DiskFlag, DiskPartIter, DiskType, DiskTypeFeature};
+pub use self::disk::{Disk, DiskFlag, DiskPartIter, DiskType, DiskTypeFeature, PartitionTableType};
 pub use self::file_system::{
     FileSystem, FileSystemAlias, FileSystemAliasIter, FileSystemType, FileSystemTypeIter,
 };


### PR DESCRIPTION
It took me a bit of code-reading to figure out how to create a partition table, so I hope that this tidied-up API is a little nicer. Here's the gist:

* I renamed the `DiskType::new` method to `DiskType::from_table_type` by creating a similar method and deprecating the old one
* I moved the most commonly used partitioning styles into an enum with a fallback option
* I added a shorthand for creating a partition table directly with `Disk::new_with_partition_table`

Hope it's alright